### PR TITLE
add missing --convert parameter to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ pip install protobuf
 ## example
 
 ```
-$ python decoder.py "otpauth-migration://offline?data=CjEKCkhlbGxvId6tvu8SGEV4YW1wbGU6YWxpY2VAZ29vZ2xlLmNvbRoHRXhhbXBsZTAC"
+$ python decoder.py --convert "otpauth-migration://offline?data=CjEKCkhlbGxvId6tvu8SGEV4YW1wbGU6YWxpY2VAZ29vZ2xlLmNvbRoHRXhhbXBsZTAC"
 ```
 
 


### PR DESCRIPTION
The script doesn't work without  --convert parameter